### PR TITLE
Restore logging to stderr instead of stdout

### DIFF
--- a/pkg/utils/logging.go
+++ b/pkg/utils/logging.go
@@ -25,7 +25,6 @@ var Logger = logrus.New()
 
 func init() {
 	Logger.SetFormatter(&logrus.TextFormatter{})
-	Logger.SetOutput(os.Stdout)
 
 	// defaults to Info log level
 	Logger.SetLevel(logrus.InfoLevel)


### PR DESCRIPTION
Otherwise it makes it hard to redirect the output.

Like when testing ansible, with `LOG_LEVEL=debug`