### PR TITLE
Add container inspect wrapper for podman 4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-github/v24 v24.0.1
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/moby/sys/signal v0.7.0
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.3.0
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGi
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/moby/sys/signal v0.7.0 h1:25RW3d5TnQEoKvRbEKUGay6DCQ46IxAVTT9CUMgmsSI=
+github.com/moby/sys/signal v0.7.0/go.mod h1:GQ6ObYZfqacOwTtlXvcmh9A26dVRul/hbOZn88Kg8Tg=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -44,6 +46,7 @@ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAG
 golang.org/x/sys v0.0.0-20180824143301-4910a1d54f87/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c h1:aFV+BgZ4svzjfabn8ERpuB4JI4N6/rdy1iusx77G3oU=
 golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -30,7 +30,6 @@ import (
 	"github.com/brightzheng100/vind/pkg/docker"
 	"github.com/brightzheng100/vind/pkg/exec"
 	"github.com/brightzheng100/vind/pkg/utils"
-	"github.com/docker/docker/api/types"
 	"github.com/ghodss/yaml"
 	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
@@ -246,7 +245,7 @@ func (c *cluster) Show(machineNames []string) (machines []*Machine, err error) {
 					continue
 				}
 
-				var inspect types.ContainerJSON
+				var inspect InspectContainerJSON
 				if err := docker.InspectObject(m.containerName, ".", &inspect); err != nil {
 					return machines, err
 				}

--- a/pkg/cluster/inspect_linux.go
+++ b/pkg/cluster/inspect_linux.go
@@ -1,0 +1,90 @@
+//go:build linux
+
+package cluster
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/moby/sys/signal"
+)
+
+type InspectContainerJSON struct {
+	*types.ContainerJSONBase
+	Mounts          []types.MountPoint
+	Config          *InspectContainerConfig
+	NetworkSettings *types.NetworkSettings
+}
+
+type InspectContainerConfig struct {
+	container.Config
+}
+
+// UnmarshalJSON allow compatibility with podman V4 API
+func (insp *InspectContainerConfig) UnmarshalJSON(data []byte) error {
+	type Alias InspectContainerConfig
+	aux := &struct {
+		Entrypoint interface{} `json:"Entrypoint"`
+		StopSignal interface{} `json:"StopSignal"`
+		*Alias
+	}{
+		Alias: (*Alias)(insp),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	switch entrypoint := aux.Entrypoint.(type) {
+	case string:
+		insp.Entrypoint = strings.Split(entrypoint, " ")
+	case []string:
+		insp.Entrypoint = entrypoint
+	case []interface{}:
+		insp.Entrypoint = []string{}
+		for _, entry := range entrypoint {
+			if str, ok := entry.(string); ok {
+				insp.Entrypoint = append(insp.Entrypoint, str)
+			}
+		}
+	case nil:
+		insp.Entrypoint = []string{}
+	default:
+		return fmt.Errorf("cannot unmarshal Config.Entrypoint of type  %T", entrypoint)
+	}
+
+	switch stopsignal := aux.StopSignal.(type) {
+	case string:
+		insp.StopSignal = stopsignal
+	case float64:
+		insp.StopSignal = ToDockerFormat(uint(stopsignal))
+	case nil:
+		break
+	default:
+		return fmt.Errorf("cannot unmarshal Config.StopSignal of type  %T", stopsignal)
+	}
+	return nil
+}
+
+// ParseSysSignalToName translates syscall.Signal to its name in the operating system.
+// For example, syscall.Signal(9) will return "KILL" on Linux system.
+func ParseSysSignalToName(s syscall.Signal) (string, error) {
+	for k, v := range signal.SignalMap {
+		if v == s {
+			return k, nil
+		}
+	}
+	return "", fmt.Errorf("unknown syscall signal: %s", s)
+}
+
+func ToDockerFormat(s uint) string {
+	signalStr, err := ParseSysSignalToName(syscall.Signal(s))
+	if err != nil {
+		return strconv.FormatUint(uint64(s), 10)
+	}
+	return fmt.Sprintf("SIG%s", signalStr)
+}

--- a/pkg/cluster/inspect_other.go
+++ b/pkg/cluster/inspect_other.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package cluster
+
+import (
+	"github.com/docker/docker/api/types"
+)
+
+type InspectContainerJSON struct {
+	types.ContainerJSON
+}


### PR DESCRIPTION
The inspect format differed in some types like StopSignal, making Unmarshal fail when using podman instead of docker.

Without this fix, podman breaks:
`Error: json: cannot unmarshal number into Go struct field Config.Config.StopSignal of type string`

With this fix, podman 4.9.3 works.

Using the docker pkg/signal (now in moby) and the podman pkg/signal helper functions, instead of importing all of libpod.

This is a NOOP, on other OS.

Since they can be updated*...

\* That is, running a newer Podman 5 in the Podman Machine instead of the one that is available in the Linux distribution.

Closes #9 

----

https://github.com/containers/podman/blob/v5.4.0/libpod/define/container_inspect.go#L111

https://github.com/containers/podman/blob/v5.4.0/pkg/signal/signal_common.go#L66
